### PR TITLE
Add `Character.secretBackstory` in Star Wars' schema

### DIFF
--- a/argo-js/test/equivalence/starwars/schema.graphql
+++ b/argo-js/test/equivalence/starwars/schema.graphql
@@ -11,6 +11,7 @@ interface Character {
   name: String
   friends: [Character]
   appearsIn: [Episode]
+  secretBackstory: String
 }
 
 type Human implements Character {


### PR DESCRIPTION
The [TypeScript definition had the field][1], but not the dumped schema. I'm assuming the presence of the field is public, otherwise the clients could not request it, nor build a wire types for it.

In case you're wondering, I'm using the [equivalence tests to generate test data](https://github.com/jbourassa/argo/commit/eedd48925ce5187d9cbc72cff6e8e0d44bbb3b23) implementations we're working on.

[1]: https://github.com/msolomon/argo/blob/49fceceed4714ee26a5e4608728d54431bc040c9/argo-js/test/equivalence/starwarsequivalence.ts#L307-L310