### PR TITLE
Additional steps for 'CollectFieldWireTypes' to support include/skip directives

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -301,9 +301,17 @@ CollectFieldWireTypes(selectionType, selectionSet):
 - For each {alias} and ordered set of {fields} in {CollectFieldsStatic(selectionSet)}:
   - For each {field} in {fields}:
     - Initialize {omittable} to {false}
-    - If {field} was selected by a fragment spread, set {typeCondition} to the name of the fragment
-    - If {field} was selected by an inline fragment, set {typeCondition} to the name of the type condition specified in the inline fragment
-    - If {typeCondition} is set, but not set to the name of {selectionType}, set omittable to {true}
+    - If {field} was selected by a fragment spread, set {typeCondition} to the name of the type condition specified in the fragment definition
+    - If {field} was selected by an inline fragment and a type condition has been specified, set {typeCondition} to the name of the type condition specified in the inline fragment
+    - If {typeCondition} is set, but not set to the name of {selectionType}, set {omittable} to {true}
+    - If {field} provides the directive `@include`, let {includeDirective} be that directive.
+      - If {includeDirective}'s {if} argument is variable, set {omittable} to {true}
+    - If {field} provides the directive `@skip`, let {skipDirective} be that directive.
+      - If {skipDirective}'s {if} argument is variable, set {omittable} to {true}
+    - If {field} was selected by a fragment spread or inline fragment that provides the directive `@include`, let {includeDirective} be that directive.
+      - If {includeDirective}'s {if} argument is variable, set {omittable} to {true}
+    - If {field} was selected by a fragment spread or inline fragment that provides the directive `@skip`, let {skipDirective} be that directive.
+      - If {skipDirective}'s {if} argument is variable, set {omittable} to {true}
     - If {field} is a selection set:
       - Set {wrapped} to the result of calling {TypeToWireType()} with the {field}'s GraphQL type
       -


### PR DESCRIPTION
Related to msolomon/argo#8, this is an initial PR to adjust the wording of `CollectFieldWireTypes` for `@include` and `@skip` directives as implemented in [`argo_typer.erl`](https://github.com/WhatsApp/erlang-argo/blob/8559e0a3f453ff3637f5035af9d892a1948e077c/apps/argo/src/argo_typer.erl#L487-L529).

Right now, it's very repetitive, but reflects what the code currently does.