### PR TITLE
Rename `Field.type` to `Field.of`

### DIFF
--- a/argo-js/src/decoder.ts
+++ b/argo-js/src/decoder.ts
@@ -120,7 +120,7 @@ export class ArgoDecoder {
       case 'RECORD':
         this.track(path, 'record', buf, {})
         const obj: { [key: string]: any } = {}
-        for (const { name, type, omittable } of wt.fields) {
+        for (const { name, of: type, omittable } of wt.fields) {
           if (Wire.isLabeled(type)) {
             this.count('field: labeled')
           } else if (omittable) {

--- a/argo-js/src/encoder.ts
+++ b/argo-js/src/encoder.ts
@@ -184,7 +184,7 @@ export class ArgoEncoder {
       case 'RECORD': {
         this.track(path, 'record with num fields', this.buf, wt.fields.length)
 
-        for (const { name, type, omittable } of wt.fields) {
+        for (const { name, of: type, omittable } of wt.fields) {
           if (js && name in js && js[name] != null) {
             // field actually present
             if (omittable && !Wire.isLabeled(type)) {

--- a/argo-js/src/typer.ts
+++ b/argo-js/src/typer.ts
@@ -48,8 +48,8 @@ export class Typer {
 
   rootWireType(): Wire.Type {
     const fields = [
-      { name: 'data', type: Wire.nullable(this.dataWireType()), omittable: false },
-      { name: 'errors', type: Wire.nullable({ type: Wire.TypeKey.ARRAY, of: Wire.DESC }), omittable: true },
+      { name: 'data', of: Wire.nullable(this.dataWireType()), omittable: false },
+      { name: 'errors', of: Wire.nullable({ type: Wire.TypeKey.ARRAY, of: Wire.DESC }), omittable: true },
     ]
     return { type: Wire.TypeKey.RECORD, fields }
   }
@@ -154,12 +154,12 @@ export class Typer {
           recordNodes.push(field)
           const getField = this.makeGetField(f.type)
           const type = wrapRecord(this.collectFieldWireTypes(f.type, field.selectionSet, getField))
-          const wfield: Wire.Field = { name: alias, type, omittable }
+          const wfield: Wire.Field = { name: alias, of: type, omittable }
           recordFields.push(wfield)
         } else {
           const type = this.typeToWireType(f.type)
           this.types.set(field, type)
-          recordFields.push({ name: alias, type, omittable })
+          recordFields.push({ name: alias, of: type, omittable })
         }
       }
     }
@@ -191,7 +191,7 @@ export class Typer {
           const combinedFields: Wire.Field[] = []
           const nodesToUpdate: FieldNode[] = []
           for (const field of fields) {
-            const { t, wrap } = this.unwrap(field.type)
+            const { t, wrap } = this.unwrap(field.of)
             if (!Wire.isRECORD(t)) {
               // overlapping scalars always have matching types in valid queries
               recordFields.push(field)
@@ -203,7 +203,7 @@ export class Typer {
 
             for (const [node, wtype] of this.types) {
               // TODO: optimize, probably with a reverse map
-              if (wtype === field.type) {
+              if (wtype === field.of) {
                 nodesToUpdate.push(node)
               }
             }
@@ -215,7 +215,7 @@ export class Typer {
             this.types.set(node, type)
           }
 
-          recordFields.push({ name, type, omittable: false })
+          recordFields.push({ name, of: type, omittable: false })
         }
       }
     }

--- a/argo-js/src/wire.ts
+++ b/argo-js/src/wire.ts
@@ -50,7 +50,7 @@ export namespace Wire {
 
   export type Field = {
     name: string
-    type: Wire.Type
+    of: Wire.Type
     omittable: boolean
   }
 
@@ -58,18 +58,18 @@ export namespace Wire {
   const LOCATION: Type = {
     type: TypeKey.RECORD,
     fields: [
-      { name: 'line', type: VarintBlock, omittable: false },
-      { name: 'column', type: VarintBlock, omittable: false },
+      { name: 'line', of: VarintBlock, omittable: false },
+      { name: 'column', of: VarintBlock, omittable: false },
     ],
   }
 
   export const ERROR: Type = {
     type: TypeKey.RECORD,
     fields: [
-      { name: 'message', type: block(Wire.STRING, 'String', deduplicateByDefault(Wire.STRING)), omittable: false },
-      { name: 'locations', type: { type: TypeKey.ARRAY, of: LOCATION }, omittable: true },
-      { name: 'path', type: PATH, omittable: true },
-      { name: 'extensions', type: DESC, omittable: true },
+      { name: 'message', of: block(Wire.STRING, 'String', deduplicateByDefault(Wire.STRING)), omittable: false },
+      { name: 'locations', of: { type: TypeKey.ARRAY, of: LOCATION }, omittable: true },
+      { name: 'path', of: PATH, omittable: true },
+      { name: 'extensions', of: DESC, omittable: true },
     ],
   }
 
@@ -138,7 +138,7 @@ export namespace Wire {
         case 'ARRAY':
           return recurse(wt.of) + '[]'
         case 'RECORD':
-          const fs = wt.fields.map(({ name, type, omittable }) => idnt(1) + `${name}${omittable ? '?' : ''}: ${recurse(type).trimStart()}`)
+          const fs = wt.fields.map(({ name, of: type, omittable }) => idnt(1) + `${name}${omittable ? '?' : ''}: ${recurse(type).trimStart()}`)
           return '{\n' + fs.join('\n') + '\n' + idnt() + '}'
         default:
           throw "Programmer error: print can't handle " + JSON.stringify(wt)
@@ -177,7 +177,7 @@ export namespace Wire {
         const fieldIndex = wt.fields.findIndex(({ name }) => name === fieldName)
         if (fieldIndex === -1) throw 'Encoding error: could not find record field: ' + fieldName
         const field = wt.fields[fieldIndex]
-        return [fieldIndex, ...pathToWirePath(field.type, tail)]
+        return [fieldIndex, ...pathToWirePath(field.of, tail)]
       }
       case 'STRING':
       case 'VARINT':
@@ -207,7 +207,7 @@ export namespace Wire {
           throw 'Encoding error: could not find record field by index: ' + fieldIndex
         }
         const field = wt.fields[fieldIndex]
-        return [field.name, ...wirePathToPath(field.type, tail)]
+        return [field.name, ...wirePathToPath(field.of, tail)]
       }
       case 'STRING':
       case 'VARINT':

--- a/argo-js/test/wire.test.ts
+++ b/argo-js/test/wire.test.ts
@@ -126,5 +126,5 @@ test('Fragment with mergeable scalars', () => {
     }`)
 
   const t = new Typer(schema, query).dataWireType()
-  expect(t).toHaveProperty('fields[0].type.of.fields[0].name', 'name')
+  expect(t).toHaveProperty('fields[0].of.of.fields[0].name', 'name')
 })

--- a/spec.html
+++ b/spec.html
@@ -12,7 +12,7 @@
 <header>
 <h1>⛵ Argo</h1>
 <section id="intro">
-<p><em>Version 1.1.3</em>. <em>Compatible with <a href="https://spec.graphql.org/October2021">GraphQL October 2021 Edition</a>.</em></p>
+<p><em>Version 1.1.4</em>. <em>Compatible with <a href="https://spec.graphql.org/October2021">GraphQL October 2021 Edition</a>.</em></p>
 <p><strong>Argo is a compact and compressible binary serialization format for</strong> <a href="https://graphql.org">GraphQL</a>. It aims to:</p>
 <ul>
 <li><strong>Minimize end-to-end latency</strong> of GraphQL responses<ul>
@@ -115,10 +115,11 @@
 <li><a href="#sec-Authors-and-contributors"><span class="spec-secid">E</span>Authors and contributors</a></li>
 <li><a href="#sec-Changelog"><span class="spec-secid">F</span>Changelog</a><ol>
 <li><a href="#sec-Version-1-1"><span class="spec-secid">F.1</span>Version 1.1</a><ol>
-<li><a href="#sec-v1-1-3"><span class="spec-secid">F.1.1</span>v1.1.3</a></li>
-<li><a href="#sec-v1-1-2"><span class="spec-secid">F.1.2</span>v1.1.2</a></li>
-<li><a href="#sec-v1-1-1"><span class="spec-secid">F.1.3</span>v1.1.1</a></li>
-<li><a href="#sec-v1-1-0"><span class="spec-secid">F.1.4</span>v1.1.0</a></li>
+<li><a href="#sec-v1-1-4"><span class="spec-secid">F.1.1</span>v1.1.4</a></li>
+<li><a href="#sec-v1-1-3"><span class="spec-secid">F.1.2</span>v1.1.3</a></li>
+<li><a href="#sec-v1-1-2"><span class="spec-secid">F.1.3</span>v1.1.2</a></li>
+<li><a href="#sec-v1-1-1"><span class="spec-secid">F.1.4</span>v1.1.1</a></li>
+<li><a href="#sec-v1-1-0"><span class="spec-secid">F.1.5</span>v1.1.0</a></li>
 </ol>
 </li>
 <li><a href="#sec-Version-1-0"><span class="spec-secid">F.2</span>Version 1.0</a></li>
@@ -230,12 +231,12 @@ In a client-server architecture, GraphQL schemas frequently change on the server
 <section id="sec-Wire-schema-serialization" secid="3.1">
 <h2><span class="spec-secid" title="link to this section"><a href="#sec-Wire-schema-serialization">3.1</a></span>Wire schema serialization</h2>
 <p>A Wire schema or WireType may be serialized in JSON. It must be a JSON object of the form: <code>{"type": "typeName" ...attributes...}</code> where <code>typeName</code> is one of the <span class="spec-ref"><a href="#wire-types" data-name="wire-types">Wire types</a></span> as a string, and the attributes are as sketched in <em>WireType</em> above.</p>
-<pre id="example-b1dcc" class="spec-example" data-language="json"><a href="#example-b1dcc">Example № 1</a><code><span class="token punctuation">{</span>
+<pre id="example-a9511" class="spec-example" data-language="json"><a href="#example-a9511">Example № 1</a><code><span class="token punctuation">{</span>
   <span class="token property">"type"</span><span class="token operator">:</span> <span class="token string">"RECORD"</span><span class="token punctuation">,</span>
   <span class="token property">"fields"</span><span class="token operator">:</span> <span class="token punctuation">[</span>
     <span class="token punctuation">{</span>
       <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"errors"</span><span class="token punctuation">,</span>
-      <span class="token property">"type"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
+      <span class="token property">"of"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
         <span class="token property">"type"</span><span class="token operator">:</span> <span class="token string">"NULLABLE"</span><span class="token punctuation">,</span>
         <span class="token property">"of"</span><span class="token operator">:</span> <span class="token punctuation">{</span> <span class="token property">"type"</span><span class="token operator">:</span> <span class="token string">"ARRAY"</span><span class="token punctuation">,</span> <span class="token property">"of"</span><span class="token operator">:</span> <span class="token punctuation">{</span> <span class="token property">"type"</span><span class="token operator">:</span> <span class="token string">"DESC"</span> <span class="token punctuation">}</span> <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -1025,23 +1026,27 @@ Normally, Argo does not allow for direction extension to field error objects out
 <h1><span class="spec-secid" title="link to this section"><a href="#sec-Changelog">F</a></span>Changelog</h1>
 <section id="sec-Version-1-1" secid="F.1">
 <h2><span class="spec-secid" title="link to this section"><a href="#sec-Version-1-1">F.1</a></span>Version 1.1</h2>
-<section id="sec-v1-1-3" secid="F.1.1">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-v1-1-3">F.1.1</a></span>v1.1.3</h3>
+<section id="sec-v1-1-4" secid="F.1.1">
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-v1-1-4">F.1.1</a></span>v1.1.4</h3>
+<p>Renamed <code>Field.type</code> to <code>Field.of</code> in the wire schema&rsquo;s JSON representation.</p>
+</section>
+<section id="sec-v1-1-3" secid="F.1.2">
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-v1-1-3">F.1.2</a></span>v1.1.3</h3>
 <p>Clarified merging of fields which are not selection sets in <em>CollectFieldWireTypes()</em> .</p>
 </section>
-<section id="sec-v1-1-2" secid="F.1.2">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-v1-1-2">F.1.2</a></span>v1.1.2</h3>
+<section id="sec-v1-1-2" secid="F.1.3">
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-v1-1-2">F.1.3</a></span>v1.1.2</h3>
 <p>Added additional notes and links.</p>
 </section>
-<section id="sec-v1-1-1" secid="F.1.3">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-v1-1-1">F.1.3</a></span>v1.1.1</h3>
+<section id="sec-v1-1-1" secid="F.1.4">
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-v1-1-1">F.1.4</a></span>v1.1.1</h3>
 <p>BREAKING CHANGE &ndash; some changes are backwards incompatible, but no known implementation relied on them.</p>
 <ul>
 <li><code>@include</code> and <code>@skip</code> directives <a href="https://github.com/msolomon/argo/issues/8">now result in omittable fields</a></li>
 </ul>
 </section>
-<section id="sec-v1-1-0" secid="F.1.4">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-v1-1-0">F.1.4</a></span>v1.1.0</h3>
+<section id="sec-v1-1-0" secid="F.1.5">
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-v1-1-0">F.1.5</a></span>v1.1.0</h3>
 <p>BREAKING CHANGE &ndash; some changes are backwards incompatible, but no known implementation relied on them.</p>
 <ul>
 <li>Introduced compact paths for errors (and with an eye to streaming) by encoding as a list of integers, described in <a href="#sec-Path-value-transformation">Path value transformation</a></li>
@@ -1231,10 +1236,11 @@ Written in <a href="https://spec-md.com" target="_blank">Spec Markdown</a>.</foo
 <li id="_sidebar_F.1"><a href="#sec-Version-1-1"><span class="spec-secid">F.1</span>Version 1.1</a>
 <input hidden class="toggle" type="checkbox" id="_toggle_F.1" /><label for="_toggle_F.1"></label>
 <ol>
-<li id="_sidebar_F.1.1"><a href="#sec-v1-1-3"><span class="spec-secid">F.1.1</span>v1.1.3</a></li>
-<li id="_sidebar_F.1.2"><a href="#sec-v1-1-2"><span class="spec-secid">F.1.2</span>v1.1.2</a></li>
-<li id="_sidebar_F.1.3"><a href="#sec-v1-1-1"><span class="spec-secid">F.1.3</span>v1.1.1</a></li>
-<li id="_sidebar_F.1.4"><a href="#sec-v1-1-0"><span class="spec-secid">F.1.4</span>v1.1.0</a></li>
+<li id="_sidebar_F.1.1"><a href="#sec-v1-1-4"><span class="spec-secid">F.1.1</span>v1.1.4</a></li>
+<li id="_sidebar_F.1.2"><a href="#sec-v1-1-3"><span class="spec-secid">F.1.2</span>v1.1.3</a></li>
+<li id="_sidebar_F.1.3"><a href="#sec-v1-1-2"><span class="spec-secid">F.1.3</span>v1.1.2</a></li>
+<li id="_sidebar_F.1.4"><a href="#sec-v1-1-1"><span class="spec-secid">F.1.4</span>v1.1.1</a></li>
+<li id="_sidebar_F.1.5"><a href="#sec-v1-1-0"><span class="spec-secid">F.1.5</span>v1.1.0</a></li>
 </ol>
 </li>
 <li id="_sidebar_F.2"><a href="#sec-Version-1-0"><span class="spec-secid">F.2</span>Version 1.0</a></li>

--- a/spec.md
+++ b/spec.md
@@ -1,6 +1,6 @@
 # ⛵ Argo
 
-_Version 1.1.3_.
+_Version 1.1.4_.
 _Compatible with [GraphQL October 2021 Edition](https://spec.graphql.org/October2021)._
 
 **Argo is a compact and compressible binary serialization format for** [GraphQL](https://graphql.org).
@@ -169,7 +169,7 @@ It must be a JSON object of the form: `{"type": "typeName" ...attributes...}` wh
   "fields": [
     {
       "name": "errors",
-      "type": {
+      "of": {
         "type": "NULLABLE",
         "of": { "type": "ARRAY", "of": { "type": "DESC" } }
       },
@@ -1034,6 +1034,10 @@ A big Thank You to these fine folks who have contributed on GitHub!
 # F. Changelog
 
 ## Version 1.1
+
+### v1.1.4
+
+Renamed `Field.type` to `Field.of` in the wire schema's JSON representation.
 
 ### v1.1.3
 

--- a/versions/1.1/spec.html
+++ b/versions/1.1/spec.html
@@ -12,7 +12,7 @@
 <header>
 <h1>⛵ Argo</h1>
 <section id="intro">
-<p><em>Version 1.1.3</em>. <em>Compatible with <a href="https://spec.graphql.org/October2021">GraphQL October 2021 Edition</a>.</em></p>
+<p><em>Version 1.1.4</em>. <em>Compatible with <a href="https://spec.graphql.org/October2021">GraphQL October 2021 Edition</a>.</em></p>
 <p><strong>Argo is a compact and compressible binary serialization format for</strong> <a href="https://graphql.org">GraphQL</a>. It aims to:</p>
 <ul>
 <li><strong>Minimize end-to-end latency</strong> of GraphQL responses<ul>
@@ -115,10 +115,11 @@
 <li><a href="#sec-Authors-and-contributors"><span class="spec-secid">E</span>Authors and contributors</a></li>
 <li><a href="#sec-Changelog"><span class="spec-secid">F</span>Changelog</a><ol>
 <li><a href="#sec-Version-1-1"><span class="spec-secid">F.1</span>Version 1.1</a><ol>
-<li><a href="#sec-v1-1-3"><span class="spec-secid">F.1.1</span>v1.1.3</a></li>
-<li><a href="#sec-v1-1-2"><span class="spec-secid">F.1.2</span>v1.1.2</a></li>
-<li><a href="#sec-v1-1-1"><span class="spec-secid">F.1.3</span>v1.1.1</a></li>
-<li><a href="#sec-v1-1-0"><span class="spec-secid">F.1.4</span>v1.1.0</a></li>
+<li><a href="#sec-v1-1-4"><span class="spec-secid">F.1.1</span>v1.1.4</a></li>
+<li><a href="#sec-v1-1-3"><span class="spec-secid">F.1.2</span>v1.1.3</a></li>
+<li><a href="#sec-v1-1-2"><span class="spec-secid">F.1.3</span>v1.1.2</a></li>
+<li><a href="#sec-v1-1-1"><span class="spec-secid">F.1.4</span>v1.1.1</a></li>
+<li><a href="#sec-v1-1-0"><span class="spec-secid">F.1.5</span>v1.1.0</a></li>
 </ol>
 </li>
 <li><a href="#sec-Version-1-0"><span class="spec-secid">F.2</span>Version 1.0</a></li>
@@ -230,12 +231,12 @@ In a client-server architecture, GraphQL schemas frequently change on the server
 <section id="sec-Wire-schema-serialization" secid="3.1">
 <h2><span class="spec-secid" title="link to this section"><a href="#sec-Wire-schema-serialization">3.1</a></span>Wire schema serialization</h2>
 <p>A Wire schema or WireType may be serialized in JSON. It must be a JSON object of the form: <code>{"type": "typeName" ...attributes...}</code> where <code>typeName</code> is one of the <span class="spec-ref"><a href="#wire-types" data-name="wire-types">Wire types</a></span> as a string, and the attributes are as sketched in <em>WireType</em> above.</p>
-<pre id="example-b1dcc" class="spec-example" data-language="json"><a href="#example-b1dcc">Example № 1</a><code><span class="token punctuation">{</span>
+<pre id="example-a9511" class="spec-example" data-language="json"><a href="#example-a9511">Example № 1</a><code><span class="token punctuation">{</span>
   <span class="token property">"type"</span><span class="token operator">:</span> <span class="token string">"RECORD"</span><span class="token punctuation">,</span>
   <span class="token property">"fields"</span><span class="token operator">:</span> <span class="token punctuation">[</span>
     <span class="token punctuation">{</span>
       <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"errors"</span><span class="token punctuation">,</span>
-      <span class="token property">"type"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
+      <span class="token property">"of"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
         <span class="token property">"type"</span><span class="token operator">:</span> <span class="token string">"NULLABLE"</span><span class="token punctuation">,</span>
         <span class="token property">"of"</span><span class="token operator">:</span> <span class="token punctuation">{</span> <span class="token property">"type"</span><span class="token operator">:</span> <span class="token string">"ARRAY"</span><span class="token punctuation">,</span> <span class="token property">"of"</span><span class="token operator">:</span> <span class="token punctuation">{</span> <span class="token property">"type"</span><span class="token operator">:</span> <span class="token string">"DESC"</span> <span class="token punctuation">}</span> <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -1025,23 +1026,27 @@ Normally, Argo does not allow for direction extension to field error objects out
 <h1><span class="spec-secid" title="link to this section"><a href="#sec-Changelog">F</a></span>Changelog</h1>
 <section id="sec-Version-1-1" secid="F.1">
 <h2><span class="spec-secid" title="link to this section"><a href="#sec-Version-1-1">F.1</a></span>Version 1.1</h2>
-<section id="sec-v1-1-3" secid="F.1.1">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-v1-1-3">F.1.1</a></span>v1.1.3</h3>
+<section id="sec-v1-1-4" secid="F.1.1">
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-v1-1-4">F.1.1</a></span>v1.1.4</h3>
+<p>Renamed <code>Field.type</code> to <code>Field.of</code> in the wire schema&rsquo;s JSON representation.</p>
+</section>
+<section id="sec-v1-1-3" secid="F.1.2">
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-v1-1-3">F.1.2</a></span>v1.1.3</h3>
 <p>Clarified merging of fields which are not selection sets in <em>CollectFieldWireTypes()</em> .</p>
 </section>
-<section id="sec-v1-1-2" secid="F.1.2">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-v1-1-2">F.1.2</a></span>v1.1.2</h3>
+<section id="sec-v1-1-2" secid="F.1.3">
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-v1-1-2">F.1.3</a></span>v1.1.2</h3>
 <p>Added additional notes and links.</p>
 </section>
-<section id="sec-v1-1-1" secid="F.1.3">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-v1-1-1">F.1.3</a></span>v1.1.1</h3>
+<section id="sec-v1-1-1" secid="F.1.4">
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-v1-1-1">F.1.4</a></span>v1.1.1</h3>
 <p>BREAKING CHANGE &ndash; some changes are backwards incompatible, but no known implementation relied on them.</p>
 <ul>
 <li><code>@include</code> and <code>@skip</code> directives <a href="https://github.com/msolomon/argo/issues/8">now result in omittable fields</a></li>
 </ul>
 </section>
-<section id="sec-v1-1-0" secid="F.1.4">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-v1-1-0">F.1.4</a></span>v1.1.0</h3>
+<section id="sec-v1-1-0" secid="F.1.5">
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-v1-1-0">F.1.5</a></span>v1.1.0</h3>
 <p>BREAKING CHANGE &ndash; some changes are backwards incompatible, but no known implementation relied on them.</p>
 <ul>
 <li>Introduced compact paths for errors (and with an eye to streaming) by encoding as a list of integers, described in <a href="#sec-Path-value-transformation">Path value transformation</a></li>
@@ -1231,10 +1236,11 @@ Written in <a href="https://spec-md.com" target="_blank">Spec Markdown</a>.</foo
 <li id="_sidebar_F.1"><a href="#sec-Version-1-1"><span class="spec-secid">F.1</span>Version 1.1</a>
 <input hidden class="toggle" type="checkbox" id="_toggle_F.1" /><label for="_toggle_F.1"></label>
 <ol>
-<li id="_sidebar_F.1.1"><a href="#sec-v1-1-3"><span class="spec-secid">F.1.1</span>v1.1.3</a></li>
-<li id="_sidebar_F.1.2"><a href="#sec-v1-1-2"><span class="spec-secid">F.1.2</span>v1.1.2</a></li>
-<li id="_sidebar_F.1.3"><a href="#sec-v1-1-1"><span class="spec-secid">F.1.3</span>v1.1.1</a></li>
-<li id="_sidebar_F.1.4"><a href="#sec-v1-1-0"><span class="spec-secid">F.1.4</span>v1.1.0</a></li>
+<li id="_sidebar_F.1.1"><a href="#sec-v1-1-4"><span class="spec-secid">F.1.1</span>v1.1.4</a></li>
+<li id="_sidebar_F.1.2"><a href="#sec-v1-1-3"><span class="spec-secid">F.1.2</span>v1.1.3</a></li>
+<li id="_sidebar_F.1.3"><a href="#sec-v1-1-2"><span class="spec-secid">F.1.3</span>v1.1.2</a></li>
+<li id="_sidebar_F.1.4"><a href="#sec-v1-1-1"><span class="spec-secid">F.1.4</span>v1.1.1</a></li>
+<li id="_sidebar_F.1.5"><a href="#sec-v1-1-0"><span class="spec-secid">F.1.5</span>v1.1.0</a></li>
 </ol>
 </li>
 <li id="_sidebar_F.2"><a href="#sec-Version-1-0"><span class="spec-secid">F.2</span>Version 1.0</a></li>


### PR DESCRIPTION
The BNF-like definition of `Field` says it should have a `of` field, but in the code and the JSON dump it's a `type` field instead:

    WireType ::
    - `STRING()` | `BOOLEAN()` | `VARINT()` | `FLOAT64()` | `BYTES()` | `DESC()` | `PATH()`
    - `FIXED(lengthInBytes: Int)`
    - `RECORD(fields: Field[])` where `Field(name: String, of: WireType, omittable: Boolean)`
                                                           ^^-------|
    - `ARRAY(of: WireType)`                                         |
    - `BLOCK(of: WireType, key: String, dedupe: Boolean)`           |
    - `NULLABLE(of: WireType)`                                      |
                                                                    |
    [...]                                                           |
                                                                    |
    ```                                                             |
    {                                                               |
      "type": "RECORD",                                             |
      "fields": [                                                   |
        {                                                           |
          "name": "errors",                                         |
          "type": {                                                 |
           ^^^^-----------------------------------------------------|

            "type": "NULLABLE",
            "of": { "type": "ARRAY", "of": { "type": "DESC" } }
    ```


With this rename, the code is consistent with the BNF-like definition and other `WireType`s.


This PR:
1. Renames `Field.type` to `Field.of` using the LSP rename action (and fixed a few cases it missed)
2. Regenerates the spec with `make.sh`.