### PR TITLE
Field Selection Merging demonstration of problem

### DIFF
--- a/argo-js/test/wire.test.ts
+++ b/argo-js/test/wire.test.ts
@@ -128,3 +128,66 @@ test('Fragment with mergeable scalars', () => {
   const t = new Typer(schema, query).dataWireType()
   expect(t).toHaveProperty('fields[0].of.of.fields[0].name', 'name')
 })
+
+test('Fragment with mergeable records', () => {
+  const schema = buildSchema(`
+    type Query {
+      hero: Character
+    }
+
+    interface Character { id: ID! }
+
+    type Droid implements Character {
+      id: ID!
+      properties: DroidProperties!
+    }
+    type DroidProperties {
+      x: Int!
+      y: String!
+    }
+    type Human implements Character {
+      id: ID!
+      properties: HumanProperties!
+    }
+    type HumanProperties {
+      x: Int!
+      z: String!
+    }
+  `)
+
+  const mergeQuery = parse(`
+    query {
+      hero {
+        ... on Character { id }
+        ... on Droid {
+          id
+          properties {
+            x
+            y
+          }
+        }
+        ... on Human {
+          id
+          properties {
+            x
+            z
+          }
+        }
+      }
+    }`)
+
+  const prettyWireType = (query: DocumentNode): string => Wire.print(new Typer(schema, query).dataWireType())
+
+  console.log(JSON.stringify(new Typer(schema, mergeQuery).dataWireType(), null, 2))
+
+  expect(prettyWireType(mergeQuery)).toEqual(`{
+ hero: {
+   id?: STRING<ID>
+   properties?: {
+    x: VARINT{Int}
+    y?: STRING<String>
+    z?: STRING<String>
+   }
+  }?
+}`)
+})


### PR DESCRIPTION
See [GraphQL Spec: 5.3.2 Field Selection Merging](https://spec.graphql.org/draft/#sec-Field-Selection-Merging).

The attached test case currently fails:

```diff
- Expected  -  4
+ Received  + 10

  {
    hero: {
-    id?: STRING<ID>
+    id: STRING<ID>
-    properties?: {
+    id: {
+
+    }
+    properties: {
      x: VARINT{Int}
-     y?: STRING<String>
+     x: {
+
+     }
+     y: STRING<String>
-     z?: STRING<String>
+     z: STRING<String>
      }
    }?
  }
```

Here is the JSON dump of the wire type:

```json
{
  "type": "RECORD",
  "fields": [
    {
      "name": "hero",
      "of": {
        "type": "NULLABLE",
        "of": {
          "type": "RECORD",
          "fields": [
            {
              "name": "id",
              "of": {
                "type": "BLOCK",
                "of": {
                  "type": "STRING"
                },
                "key": "ID",
                "dedupe": true
              },
              "omittable": false
            },
            {
              "name": "id",
              "of": {
                "type": "RECORD",
                "fields": []
              },
              "omittable": false
            },
            {
              "name": "properties",
              "of": {
                "type": "RECORD",
                "fields": [
                  {
                    "name": "x",
                    "of": {
                      "type": "BLOCK",
                      "of": {
                        "type": "VARINT"
                      },
                      "key": "Int",
                      "dedupe": false
                    },
                    "omittable": false
                  },
                  {
                    "name": "x",
                    "of": {
                      "type": "RECORD",
                      "fields": []
                    },
                    "omittable": false
                  },
                  {
                    "name": "y",
                    "of": {
                      "type": "BLOCK",
                      "of": {
                        "type": "STRING"
                      },
                      "key": "String",
                      "dedupe": true
                    },
                    "omittable": false
                  },
                  {
                    "name": "z",
                    "of": {
                      "type": "BLOCK",
                      "of": {
                        "type": "STRING"
                      },
                      "key": "String",
                      "dedupe": true
                    },
                    "omittable": false
                  }
                ]
              },
              "omittable": false
            }
          ]
        }
      },
      "omittable": false
    }
  ]
}
```

The _think_ the expected wire type should look like this:

```
{
  hero: {
    id?: STRING<ID>
    properties?: {
      x: VARINT{Int}
      y?: STRING<String>
      z?: STRING<String>
    }
  }?
}?
```